### PR TITLE
remove call to #railtie_name

### DIFF
--- a/lib/rails_db_views/railtie.rb
+++ b/lib/rails_db_views/railtie.rb
@@ -1,6 +1,4 @@
 class Railtie < Rails::Railtie
-  railtie_name :rails_db_views
-
   config.rails_db_views = ActiveSupport::OrderedHash.new
 
   initializer "rails_db_views.initialize" do |app|


### PR DESCRIPTION
@wcmonty we're getting a deprecation message because of this. In fact, I looked at the rails source and here is the method definition, lol:

```ruby
def railtie_name(*)
  ActiveSupport::Deprecation.warn "railtie_name is deprecated and has no effect", caller
end
```

Side note: are you ok with changing the owner of your fork to Rigor?