### PR TITLE
Add db:schema:load to list of augmented tasks

### DIFF
--- a/lib/tasks/rails_db_views_tasks.rake
+++ b/lib/tasks/rails_db_views_tasks.rake
@@ -28,7 +28,7 @@ namespace :db do
 end
 
 # prepend "db" namespace
-db_tasks = %w(migrate rollback test:load test:prepare).map { |task_name| "db:#{task_name}" }
+db_tasks = %w(migrate rollback test:load test:prepare schema:load).map { |task_name| "db:#{task_name}" }
 
 db_tasks.each do |task_name|
   # Before


### PR DESCRIPTION
This way a `rake db:reset` will add the db views for me. (Up 'til now I've also been running db:migrate every time just to get the db views in place.)